### PR TITLE
Attempt to fix rendering of dotpoints in overview in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 The Fender-Bender library began as a way to externalize and isolate some common [build123d](https://github.com/gumyr/build123d) utilities, functions, & methods from the [Fender-Bender](https://github.com/x0pherl/fender-bender) project.
 
 It's grown to include some capabilities not required by that project. Useful components include:
+
 - dovetail: Splits a build123d `Part` object into two parts that can easily be slid together with very tight tolerances. Useful when building parts larger than your printer's build volume.
 - click_fit: a tapered profile that allows for better printing & assembly than a simple half Sphere to allow parts to "click" or snap into place when fit together. The extruded shape and the socket are both shaped carefully to allow a mix of easy assembly and good hold.
 - point: a lightweight X,Y coordinate point object with some geometric functions built into the object.
-- hexwall: builds a field of hexagons with gaps in-between within a given set of bounds
+- hexwall: builds a field of hexagons with gaps in-between within a given set of bounds.
 
 # Documentation
 


### PR DESCRIPTION
On the docs page these dot points are rendering as inline text.
<img width="2630" height="378" alt="image" src="https://github.com/user-attachments/assets/9d668198-a808-46b9-8f12-680513e777b1" />

Presumably because it is using a different markdown engine to github.

I am hoping this fixes it.